### PR TITLE
Make strings work (fixes #2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports = function (path, opts, cb) {
       read(null, function next (end, data) {
         if(end === true) fs.close(fd, cb)
         else if(end)     cb(end) //error!
-        else
+        else  
+          if(typeof data === 'string') data = Buffer.from(data) // convert strings to buffers
           fs.write(fd, data, 0, data.length, pos, function (err, bytes) {
             if(err) read(err, function () { fs.close(fd, cb) })
             else    pos += bytes, read(null, next)


### PR DESCRIPTION
Couldn't really be done more elegantly since the signature for ``fs.write`` for a buffer and a string is very different.