### PR TITLE
Fix invalid strict-mode syntax with fs constants

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,13 @@ module.exports = function (path, opts, cb) {
   if('function' == typeof opts)
     cb = opts, opts = null
   var flags = opts && opts.flags || 'w'
-  var mode = opts && opts.mode || 0666
+
+  const ownerReadWrite = fs.constants.S_IRUSR + fs.constants.S_IWUSR
+  const groupReadWrite = fs.constants.S_IRGRP + fs.constants.S_IWGRP
+  const otherReadWrite = fs.constants.S_IROTH + fs.constants.S_IWOTH
+  const defaultMode = ownerReadWrite + groupReadWrite + otherReadWrite
+
+  var mode = opts && opts.mode || defaultMode
   var pos = 0
   return function (read) {
     fs.open(path, flags, mode, function (err, fd) {


### PR DESCRIPTION
This resolves an issue where the module wasn't able to be parsed in strict mode.

See: ssbc/ssb-server#683